### PR TITLE
Implement Pausable

### DIFF
--- a/packages/token/src/Hooks.ts
+++ b/packages/token/src/Hooks.ts
@@ -45,13 +45,19 @@ class Hooks extends SmartContract implements _Hooks {
     const admin = this.admin.get();
     this.admin.assertEquals(admin);
 
-    // example of disabling `setPaused`
-    const actionPossible = action.type
-      .equals(AdminAction.types.setPaused)
-      .equals(Bool(false));
+    //  If you want to disallow some AdminActions, you can do
+    //  that via an assert statement like this:
+    //const actionPossible = action.type
+    //  .equals(AdminAction.types.setPaused)
+    //  .equals(Bool(false));
+    //actionPossible.assertTrue();
+    //  This would check that the action is not setPaused,
+    //  and thus disallow pausing/unpausing token transfers.
 
-    actionPossible.assertTrue();
+    // If you want to allow any AdminAction, unconditioanlly return true.
+    const actionPossible = Bool(true);
 
+    // Require a signature from the admin
     const adminAccountUpdate = AccountUpdate.create(admin);
     adminAccountUpdate.requireSignature();
 

--- a/packages/token/src/errors.ts
+++ b/packages/token/src/errors.ts
@@ -10,6 +10,8 @@ const errors = {
 
   mintAmountExceedsTotalSupply:
     'Minting the provided amount would overflow the total supply',
+
+  tokenPaused: 'Token is paused',
 };
 
 export default errors;

--- a/packages/token/src/token.ts
+++ b/packages/token/src/token.ts
@@ -82,6 +82,11 @@ class Token
     return new Hooks(admin);
   }
 
+  public assertNotPaused(): void {
+    this.paused.assertEquals(this.paused.get());
+    this.paused.get().assertFalse(errors.tokenPaused);
+  }
+
   @method
   public initialize(hooks: PublicKey, totalSupply: UInt64) {
     super.init();
@@ -99,6 +104,8 @@ class Token
 
   @method
   public mint(to: PublicKey, amount: UInt64): AccountUpdate {
+    this.assertNotPaused();
+
     const hooksContract = this.getHooksContract();
     hooksContract.canAdmin(AdminAction.fromType(AdminAction.types.mint));
 
@@ -133,6 +140,8 @@ class Token
 
   @method
   public burn(from: PublicKey, amount: UInt64): AccountUpdate {
+    this.assertNotPaused();
+
     const hooksContract = this.getHooksContract();
     hooksContract.canAdmin(AdminAction.fromType(AdminAction.types.burn));
 
@@ -205,6 +214,8 @@ class Token
 
   @method
   public approveTransfer(from: AccountUpdate, to: AccountUpdate): void {
+    this.assertNotPaused();
+
     this.assertHasNoBalanceChange([from, to]);
     this.approve(from, AccountUpdate.Layout.NoChildren);
     this.approve(to, AccountUpdate.Layout.NoChildren);
@@ -212,6 +223,8 @@ class Token
 
   @method
   public approveDeploy(deploy: AccountUpdate): void {
+    this.assertNotPaused();
+
     this.assertHasNoBalanceChange([deploy]);
     this.approve(deploy, AccountUpdate.Layout.NoChildren);
   }
@@ -226,6 +239,8 @@ class Token
     to,
     amount,
   }: TransferFromToOptions): FromToTransferReturn {
+    this.assertNotPaused();
+
     const [fromAccountUpdate] = this.transferFrom(
       from,
       amount,
@@ -247,6 +262,8 @@ class Token
     amount: UInt64,
     mayUseToken: MayUseToken
   ): FromTransferReturn {
+    this.assertNotPaused();
+
     const fromAccountUpdate = AccountUpdate.create(from, this.token.id);
     fromAccountUpdate.balance.subInPlace(amount);
 
@@ -260,6 +277,8 @@ class Token
     amount: UInt64,
     mayUseToken: MayUseToken
   ): ToTransferReturn {
+    this.assertNotPaused();
+
     const toAccountUpdate = AccountUpdate.create(to, this.token.id);
 
     toAccountUpdate.body.mayUseToken = mayUseToken;
@@ -274,6 +293,8 @@ class Token
     amount,
     mayUseToken,
   }: TransferOptions): TransferReturn {
+    this.assertNotPaused();
+
     if (!from && !to) {
       throw new Error(errors.fromOrToNotProvided);
     }


### PR DESCRIPTION
This implements the functionality to pause token transfers/minting/burning, and adds corresponding tests.